### PR TITLE
Add Gastarbeiter achievement

### DIFF
--- a/sql_prep/models/achievements/achievements.yml
+++ b/sql_prep/models/achievements/achievements.yml
@@ -37,3 +37,9 @@ models:
       - name: achievement_priority
         tests:
           - not_null
+  - name: agg__gastarbeiter
+    description: >
+      Debatéři, kteří debatovali alespoň jednou se členy jiných klubů ve 
+      stejném týmu. (Ocenění dostávají jen ti, kteří svůj klub zastupovali 
+      sami, ne ti, kteří byli "v převaze".)
+    columns: *STANDARD_ACHIEVEMENT_COLUMNS

--- a/sql_prep/models/achievements/agg__gastarbeiter.sql
+++ b/sql_prep/models/achievements/agg__gastarbeiter.sql
@@ -1,0 +1,73 @@
+with base as (
+    select * from {{ ref('base__debater_debata') }}
+),
+
+team_club_count as (
+    select
+        debata_id,
+        is_affirmative_speaker,
+        klub_id,
+        count(*) as club_count
+    from base
+    group by 1, 2, 3
+),
+
+team_club_count_json as (
+    -- Group the previous query so that we can have a single row per 
+    -- team-within-debate, and a JSON object with the club counts that we can
+    -- use as a lookup table.
+    select
+        debata_id,
+        is_affirmative_speaker,
+        json_group_object(klub_id, club_count) as club_count_json
+    from team_club_count
+    where klub_id is not null
+    group by 1, 2
+),
+
+merge_back as (
+    -- Merge the JSON object back to debater-within-debate granularity
+    select
+        base.*,
+        team_club_count_json.club_count_json
+    from base
+    left join team_club_count_json using (debata_id, is_affirmative_speaker)
+),
+
+gastarbeiters as (
+    -- Subset to relevant columns before making the cull (for some reason, 
+    -- trying to do `where club_count_json->klub_id = 1` directly throws an
+    -- aggregation error)
+    select
+        clovek_id,
+        school_year,
+        klub_id,
+        club_count_json,
+        club_count_json->klub_id as teammates_from_club_in_debate
+    from merge_back
+),
+
+gastarbeiter_stats as (
+    select
+        clovek_id,
+        school_year,
+        count(*) as debate_count
+    from gastarbeiters
+    where teammates_from_club_in_debate = 1
+    group by 1, 2
+),
+
+final as (
+    select
+        clovek_id,
+        school_year,
+        'gastarbeiter/' || clovek_id || '/' || school_year as achievement_id,
+        'Gastarbeiter' as achievement_name,
+        'Debatoval jsi v týmu s členy jiných klubů! Tvá tolerance tě šlechtí.' as achievement_description,
+        json_object('debate_count', debate_count) as achievement_data,
+        'binary' as achievement_type,
+        2 as achievement_priority
+    from gastarbeiter_stats
+)
+
+select * from final

--- a/sql_prep/models/final/final__all_achievements.sql
+++ b/sql_prep/models/final/final__all_achievements.sql
@@ -9,6 +9,7 @@ with all_achievements_unioned as (
     {{
         dbt_utils.union_relations(
             relations=[
+                ref("agg__gastarbeiter"),
                 ref("agg__prehlasovan"),
                 ref("agg__multilingvni"),
             ],


### PR DESCRIPTION
Currently only awards the achievement to lone other-club members, but can easily be modified to accommodate all who participate in inter-club exchange.