### PR TITLE
Set up deployment to fly.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,9 @@ frontend:
 setup:
 	python -m venv env
 	env/Scripts/pip install -r requirements.txt
+deploy:
+	fly deploy backend/
+	fly deploy frontend/
+	echo "You need to manually deploy the database."
 
-.PHONY: run backend frontend setup adk logs
+.PHONY: run backend frontend setup adk logs deploy

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ graph TD
   B(FastAPI)   -->|Sends data to| A(Spectacle)
 ```
 
-## Environment
+## Environment (dev)
+
 
 1. Get a DuckDB export of the dataset and place it in `data/adk_wrapped.db`.
 2. Create a `profiles.yml` file in `~/.dbt` with the following contents:
@@ -54,3 +55,34 @@ graph TD
 - NOT DONE: `/gdpr` to handle initial consent and GDPR compliance (?).
 - NOT DONE: `/authenticate` to ensure Greybox 2.0 is logged into.
 
+## Deployment to fly.io
+
+We're using [fly.io](https://fly.io) to deploy the backend and frontend, both using the `Dockerfile` and `fly.toml` in the respective directories. We're basically playing the role of `docker-compose.yml` by manually handling the volumes, networking, and environment variables.
+
+### Setup
+
+The `fly.toml` files are already set up now. The prerequisites were:
+
+```bash
+cd frontend
+fly apps create adk-wrapped
+cd ../backend
+fly apps create adk-wrapped-api
+fly volumes create adk_wrapped_data --region ams --size 
+```
+
+The app is currently deployed to the Amsterdam (`ams`) region.
+
+### Deployment
+
+`make deploy` pushes both the frontend and backend to fly.io. However, to update the volume, we must ssh/SFTP into the backend nad `puts` it there manually.
+
+```bash
+cd backend
+fly ssh sftp shell
+# SFTP prompt will appear
+cd /data
+puts ../data/adk_wrapped.db
+```
+
+Before you can do either, you need to be a member of the deploying organization, which is Simon's personal one, and install fly CLI + authenticate.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,6 +9,9 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # Turns off buffering for easier container logging
 ENV PYTHONUNBUFFERED=1
 
+# Set the server if the bare Dockerfile is being launched
+ENV SERVER="0.0.0.0"
+
 # Install pip requirements
 COPY requirements.txt .
 RUN python -m pip install -r requirements.txt
@@ -22,4 +25,4 @@ RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /
 USER appuser
 
 # During debugging, this entry point will be overridden. For more information, please refer to https://aka.ms/vscode-docker-python-debug
-CMD ["gunicorn", "--bind", "backend:8765", "-k", "uvicorn.workers.UvicornWorker", "src.app:app"]
+CMD gunicorn --bind $SERVER:8765 -k uvicorn.workers.UvicornWorker src.app:app

--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn src.app:app --host 0.0.0.0 --port ${PORT}

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -1,0 +1,21 @@
+app = "adk-wrapped-api"
+primary_region = "ams"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8765"
+
+[mounts]
+  source="adk_wrapped_data"
+  destination="/data"
+
+[http_service]
+  internal_port = 8765
+  
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 200
+    hard_limit = 250
+

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -7,8 +7,11 @@ import pathlib
 app = FastAPI()
 
 # TODO: Change to dockerized location (/data/adk_wrapped.db)
-path_to_db = pathlib.Path(__file__).parent.parent.parent / "data/adk_wrapped.db"
-db = Database(path_to_db)
+try:
+    path_to_db = pathlib.Path(__file__).parent.parent.parent / "data/adk_wrapped.db"
+    db = Database(path_to_db)
+except Exception as e:
+    db = None
 
 @app.get("/api")
 def show_instructions():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       dockerfile: ./Dockerfile
     volumes:
       - ./data:/data
-    # ports:
-    #   - 8765:8765
+    environment:
+      - SERVER=backend
   frontend:
     image: frontend
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,9 @@ services:
     build:
       context: ./frontend/
       dockerfile: ./Dockerfile
+      args:
+        - BACKEND_SERVER=backend:8765
     ports:
       - 80:80
+    environment:
+      - BACKEND_SERVER=backend:8765

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,13 +10,15 @@ RUN npm ci
 RUN npm run build
 
 FROM nginx:1.23.4-alpine
+RUN apk add --no-cache gettext
 COPY --from=build /usr/src/app/build /usr/share/nginx/html
-COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY nginx/nginx.conf.template /etc/nginx/nginx.template
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
 
-# EXPOSE 3000
-# RUN chown -R node /usr/src/app
-# USER node
-# CMD ["node", "src/index.js"]
-# CMD [ "npx", "serve", "build" ]
+# Must be set in docker-compose.yml or elsewhere in environment
+ARG BACKEND_SERVER
+# RUN envsubst '${BACKEND_SERVER}' < /etc/nginx/nginx.template > /etc/nginx/nginx.conf
+RUN sed "s|__BACKEND_SERVER__|${BACKEND_SERVER}|" /etc/nginx/nginx.template > /etc/nginx/nginx.conf
+# CMD ["nginx", "-g", "daemon off;"]
+CMD /bin/sh -c "cat /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"
+# CMD /bin/sh -c "envsubst '$BACKEND_SERVER' < /etc/nginx/nginx.template > /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,24 +1,33 @@
+# 1. Use multi-stage build to reduce final image size
 FROM node:18-alpine as build
 ENV NODE_ENV=production
 WORKDIR /usr/src/app
-COPY ["package.json", "package-lock.json*", "npm-shrinkwrap.json*", "./"]
-# RUN npm install --production --silent && mv node_modules ../
 
+# 2. Copy only package.json and package-lock.json and install only prod dependencies;
+#    re-run only when package.json or package-lock.json changes
+COPY ["package.json", "package-lock.json*", "npm-shrinkwrap.json*", "./"]
+RUN npm ci --only=production
+
+# 3. Copy all other source files and build
 COPY ["./src", "./src"]
 COPY ./public ./public
-RUN npm ci
 RUN npm run build
 
+# 4. Use a smaller build image for the final image
 FROM nginx:1.23.4-alpine
-RUN apk add --no-cache gettext
 COPY --from=build /usr/src/app/build /usr/share/nginx/html
 COPY nginx/nginx.conf.template /etc/nginx/nginx.template
-EXPOSE 80
 
-# Must be set in docker-compose.yml or elsewhere in environment
+# 5. Replace __BACKEND_SERVER__ with the actual backend server in nginx.conf
+#    (Must be set in docker-compose.yml or fly.toml as a build arg)
 ARG BACKEND_SERVER
-# RUN envsubst '${BACKEND_SERVER}' < /etc/nginx/nginx.template > /etc/nginx/nginx.conf
 RUN sed "s|__BACKEND_SERVER__|${BACKEND_SERVER}|" /etc/nginx/nginx.template > /etc/nginx/nginx.conf
-# CMD ["nginx", "-g", "daemon off;"]
-CMD /bin/sh -c "cat /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"
-# CMD /bin/sh -c "envsubst '$BACKEND_SERVER' < /etc/nginx/nginx.template > /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"
+
+# Alternative, more elegant way of doing the same (that didn't work):
+# RUN apk add --no-cache gettext
+# RUN envsubst '${BACKEND_SERVER}' < /etc/nginx/nginx.template > /etc/nginx/nginx.conf
+
+# 6. Expose port 80 and start nginx
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+# CMD /bin/sh -c "cat /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"

--- a/frontend/Procfile
+++ b/frontend/Procfile
@@ -1,0 +1,1 @@
+web: nginx -g "daemon off;"

--- a/frontend/fly.toml
+++ b/frontend/fly.toml
@@ -1,0 +1,15 @@
+app = "adk-wrapped"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "80"
+
+[http_service]
+  internal_port = 80
+  
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 200
+    hard_limit = 250

--- a/frontend/fly.toml
+++ b/frontend/fly.toml
@@ -3,8 +3,13 @@ app = "adk-wrapped"
 [build]
   dockerfile = "Dockerfile"
 
+  [build.args]
+    BACKEND_SERVER = "adk-wrapped-api.fly.dev"
+
+
 [env]
   PORT = "80"
+  BACKEND_SERVER = "adk-wrapped-api.fly.dev"
 
 [http_service]
   internal_port = 80

--- a/frontend/fly.toml
+++ b/frontend/fly.toml
@@ -4,8 +4,8 @@ app = "adk-wrapped"
   dockerfile = "Dockerfile"
 
   [build.args]
+    # TODO: replace with internal address / figure out why that's not working
     BACKEND_SERVER = "adk-wrapped-api.fly.dev"
-
 
 [env]
   PORT = "80"

--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -1,6 +1,7 @@
 http {
     upstream backend {
-        server backend:8765;
+        # TODO: replace with internal address / figure out why that's not working
+        server adk-wrapped-api.fly.dev;
     }
 
     server {

--- a/frontend/nginx/nginx.conf.template
+++ b/frontend/nginx/nginx.conf.template
@@ -1,6 +1,7 @@
 http {
     upstream backend {
-        # TODO: replace with internal address / figure out why that's not working
+        # This is replaced with `sed` at container build time - see 
+        # fly.toml and docker-compose.yml for the ARG that is passed in.
         server __BACKEND_SERVER__;
     }
 

--- a/frontend/nginx/nginx.conf.template
+++ b/frontend/nginx/nginx.conf.template
@@ -1,7 +1,7 @@
 http {
     upstream backend {
         # TODO: replace with internal address / figure out why that's not working
-        server adk-wrapped-api.fly.dev;
+        server __BACKEND_SERVER__;
     }
 
     server {


### PR DESCRIPTION
This requires manual `fly ssh sftp shell` to upload the DuckDB to the
relevant volume, plus a bunch of setup + deployment steps that I'll
document in the Makefile.